### PR TITLE
pc_setup.rst: Fix link syntax

### DIFF
--- a/source/setup/pc_setup.rst
+++ b/source/setup/pc_setup.rst
@@ -73,4 +73,4 @@ from the host machine to the VM. Follow these instructions in VirtualBox.
         #. Name should be your wired adapter
         
 .. note::
-    In case you're unable to connect to a robot (i.e. `ssh <robotname>` doesn't work), try installing [Wireshark](https://www.wireshark.org/download.html) and monitoring the packets to diagnose the issue. 	Also try pinging by the expected IP address of the robot, `ping <robotname>.local`, and checking the output of `avahi-browse -av`.
+    In case you're unable to connect to a robot (i.e. `ssh <robotname>` doesn't work), try installing `Wireshark <https://www.wireshark.org/download.html>`_ and monitoring the packets to diagnose the issue. 	Also try pinging by the expected IP address of the robot, `ping <robotname>.local`, and checking the output of `avahi-browse -av`.


### PR DESCRIPTION
See VirtualBox around line 15 for an example: https://github.com/UNSWComputing/rUNSWift-docs/commit/7387d025595dba93b0b5cdac24915746bf8f6b4d#diff-c019170d1c9b6f592992d1a20eca9dfe985161ceee19a3a5ead4032bf7787ed2L15

Introduced in #26, sorry for missing it.