### PR TITLE
improve installation instructions by using requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,20 @@
 
 Repository for maintaining the Sphinx Documentation for rUNSWift.
 
+## Installing Sphinx
+
+```sh
+sudo apt install python3-sphinx
+```
+
 ## Installing Dependencies
-`sudo apt install python3-sphinx-rtd-theme`
+
+```
+pip3 install -r requirements.txt
+```
 
 ## Compiling
-To compile locally, run `make html`. 
+To compile locally, run `make html`.
 The home documentation page can be opened by opening `build/html/index.html` in a browser.
 
 ## RTD
@@ -14,7 +23,7 @@ The instructions for setting up the webhook for readthedocs is [here](https://do
 
 ## Editing Flowcharts (with draw.io)
 `source/draw.io/` contains **.png (with embedded XML)** that can be imported/exported by draw.io.
-To modify a diagram, 
+To modify a diagram,
 1. import the png file into draw.io
 2. make ammendments
 3. overwrite png file by exporting from draw.io

--- a/README.md
+++ b/README.md
@@ -2,12 +2,6 @@
 
 Repository for maintaining the Sphinx Documentation for rUNSWift.
 
-## Installing Sphinx
-
-```sh
-sudo apt install python3-sphinx
-```
-
 ## Installing Dependencies
 
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+sphinx-rtd-theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
+sphinx
+sphinx-copybutton
 sphinx-rtd-theme

--- a/source/conf.py
+++ b/source/conf.py
@@ -67,7 +67,7 @@ release = '2020'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = 'en'
+language = None
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/source/conf.py
+++ b/source/conf.py
@@ -29,7 +29,10 @@ import os
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.githubpages']
+extensions = [
+    'sphinx_copybutton'
+    'sphinx.ext.githubpages',
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -64,7 +67,7 @@ release = '2020'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:


### PR DESCRIPTION
Having a requirements.txt is the recommended way to list libraries to be installed. It makes adding more libraries easier as there is no need to modify ``README.md``.