### PR TITLE
Fix compilation errors in setup_venue_script.rst

### DIFF
--- a/source/game_preparation/setup_venue_script.rst
+++ b/source/game_preparation/setup_venue_script.rst
@@ -14,10 +14,11 @@ The script is situated in ``$RUNSWIFT_CHECKOUT_DIR/bin/setup-game``, and can be 
 
 .. note::
     The script has to only be run once when switching venues
-    
+
 .. note::
-    For the competition, the IP addresses in the range 10.0.18.0 - 10.0.18.255 are available to our team. 
+    For the competition, the IP addresses in the range 10.0.18.0 - 10.0.18.255 are available to our team.
     Currently, the following convention is used by the team:
+
 +-----------------------------------------------+-----------------------------+
 |   Router                                      |  10.0.18.1                  |
 +-----------------------------------------------+-----------------------------+
@@ -27,7 +28,7 @@ The script is situated in ``$RUNSWIFT_CHECKOUT_DIR/bin/setup-game``, and can be 
 +-----------------------------------------------+-----------------------------+
 |   Team Laptops (if we need a static address)  |  10.0.18.200 - 10.0.18.255  |
 +-----------------------------------------------+-----------------------------+
-    
-For robot IP suffixes, see `this file <https://github.com/UNSWComputing/rUNSWift/blob/master/utils/wifitools/updateWlanSetup.py>`_ .
 
-For more info, see `this file <https://github.com/UNSWComputing/rUNSWift/blob/master/bin/setup-venue.config.sh>`_ .
+For robot IP suffixes, see `updateWlanSetup.py <https://github.com/UNSWComputing/rUNSWift/blob/master/utils/wifitools/updateWlanSetup.py>`_ .
+
+For more info, see `setup-venue.config.sh <https://github.com/UNSWComputing/rUNSWift/blob/master/bin/setup-venue.config.sh>`_ .


### PR DESCRIPTION
Fixes the following two warnings:

```sh
/home/ijnek/Downloads/rUNSWift-docs/source/game_preparation/setup_venue_script.rst:21: WARNING: Explicit markup ends without a blank line; unexpected unindent.
/home/ijnek/Downloads/rUNSWift-docs/source/game_preparation/setup_venue_script.rst:3: WARNING: Duplicate explicit target name: "this file".
```