### PR TITLE
comment out unused html_static_path

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -137,7 +137,7 @@ html_logo = 'images/rUNSWift.gif'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied


### PR DESCRIPTION
Fixes the following warning:

```sh
WARNING: html_static_path entry '_static' does not exist
```